### PR TITLE
Fix win32/s390x for PR4641

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -843,7 +843,6 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_planar_rgb(self):
         # gdal_translate -co TILED=no -co INTERLEAVE=BAND -co COMPRESS=LZW \
         # tiff_strip_raw.tif tiff_strip_planar_lzw.tiff
@@ -851,7 +850,6 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_planar_rgb(self):
         # gdal_translate -co TILED=yes -co INTERLEAVE=BAND -co COMPRESS=LZW \
         # tiff_tiled_raw.tif tiff_tiled_planar_lzw.tiff
@@ -859,21 +857,18 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_adobe_deflate.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_planar_16bit_RGB(self):
         # gdal_translate -co TILED=yes -co INTERLEAVE=BAND -co COMPRESS=LZW \
         # tiff_16bit_RGB.tiff tiff_tiled_planar_16bit_RGB.tiff
         with Image.open("Tests/images/tiff_tiled_planar_16bit_RGB.tiff") as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGB_target.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_planar_16bit_RGB(self):
         # gdal_translate -co TILED=no -co INTERLEAVE=BAND -co COMPRESS=LZW \
         # tiff_16bit_RGB.tiff tiff_strip_planar_16bit_RGB.tiff
         with Image.open("Tests/images/tiff_strip_planar_16bit_RGB.tiff") as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGB_target.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_planar_16bit_RGBa(self):
         # gdal_translate -co TILED=yes \
         # -co INTERLEAVE=BAND -co COMPRESS=LZW -co ALPHA=PREMULTIPLIED \
@@ -881,7 +876,6 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/tiff_tiled_planar_16bit_RGBa.tiff") as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGBa_target.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_planar_16bit_RGBa(self):
         # gdal_translate -co TILED=no \
         # -co INTERLEAVE=BAND -co COMPRESS=LZW -co ALPHA=PREMULTIPLIED \

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -406,7 +406,7 @@ ImagingLibTiffDecode(
     UINT8 planes = 1;
     ImagingShuffler unpackers[4];
 
-    memset(unpackers, 0, sizeof(ImagingShuffler *) * 4);
+    memset(unpackers, 0, sizeof(ImagingShuffler) * 4);
 
     /* buffer is the encoded file, bytes is the length of the encoded file */
     /*     it all ends up in state->buffer, which is a uint8* from Imaging.h */

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -402,7 +402,7 @@ ImagingLibTiffDecode(
     TIFF *tiff;
     uint16 photometric = 0;  // init to not PHOTOMETRIC_YCBCR
     int isYCbCr = 0;
-    UINT8 planarconfig = 0;
+    uint16 planarconfig = 0;
     UINT8 planes = 1;
     ImagingShuffler unpackers[4];
 


### PR DESCRIPTION
Fixes stack corruption in https://github.com/python-pillow/Pillow/pull/5178

`TIFFTAG_PLANARCONFIG` is a `uint16` value, reading it into `UINT8` corrupts the `state` pointer (on win32). Big-endian was most likely the same issue.

Also change `memset(unpackers, 0, sizeof(ImagingShuffler *) * 4);` to `memset(unpackers, 0, sizeof(ImagingShuffler) * 4);` since it seems to be a typo (`ImagingShuffler` is already a pointer).