### PR TITLE
Fix BigEndian + Refactoring + Optimization

### DIFF
--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -814,13 +814,11 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/flower.jpg", 0.5)
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_strip_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_strip_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
@@ -831,13 +829,11 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open(infile) as im:
             assert_image_similar_tofile(im, "Tests/images/pil_sample_cmyk.jpg", 0.5)
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_1x1_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_1x1_sampling.tif"
         with Image.open(infile) as im:
             assert_image_equal_tofile(im, "Tests/images/flower2.jpg")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_tiled_ycbcr_jpeg_2x2_sampling(self):
         infile = "Tests/images/tiff_tiled_ycbcr_jpeg_2x2_sampling.tif"
         with Image.open(infile) as im:

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -16,7 +16,6 @@ from .helper import (
     assert_image_similar,
     assert_image_similar_tofile,
     hopper,
-    is_big_endian,
     skip_unless_feature,
 )
 
@@ -879,7 +878,6 @@ class TestFileLibTiff(LibTiffTestCase):
         with Image.open("Tests/images/tiff_strip_planar_16bit_RGBa.tiff") as im:
             assert_image_equal_tofile(im, "Tests/images/tiff_16bit_RGBa_target.png")
 
-    @pytest.mark.xfail(is_big_endian(), reason="Fails on big-endian")
     def test_old_style_jpeg(self):
         infile = "Tests/images/old-style-jpeg-compression.tif"
         with Image.open(infile) as im:

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1324,6 +1324,15 @@ class TiffImageFile(ImageFile.ImageFile):
             if ";16L" in rawmode:
                 rawmode = rawmode.replace(";16L", ";16N")
 
+            # YCbCr images with new jpeg compression with pixels in one plane
+            # unpacked straight into RGB values
+            if (
+                photo == 6
+                and self._compression == "jpeg"
+                and self._planar_configuration == 1
+            ):
+                rawmode = "RGB"
+
             # Offset in the tile tuple is 0, we go from 0,0 to
             # w,h, and we only do this once -- eds
             a = (rawmode, self._compression, False, self.tag_v2.offset)

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -389,17 +389,6 @@ _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imaging
         return -1;
     }
 
-    state->bytes = tile_bytes_size;
-
-    /* realloc to fit whole tile */
-    /* malloc check above */
-    new_data = realloc(state->buffer, state->bytes);
-    if (!new_data) {
-        state->errcode = IMAGING_CODEC_MEMORY;
-        return -1;
-    }
-    state->buffer = new_data;
-
     TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
     TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
 
@@ -409,7 +398,26 @@ _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imaging
         return -1;
     }
 
+    if (tile_bytes_size > ((tile_length * state->bits / planes + 7) / 8) * tile_width) {
+        // If the tile size as expected by LibTiff isn't what we're expecting, abort.
+        // man:   TIFFTileSize returns the equivalent size for a tile of data as it would be returned in a
+        //        call to TIFFReadTile ...
+        state->errcode = IMAGING_CODEC_BROKEN;
+        return -1;
+    }
+
+    state->bytes = tile_bytes_size;
+
     TRACE(("TIFFTileSize: %d\n", state->bytes));
+
+    /* realloc to fit whole tile */
+    /* malloc check above */
+    new_data = realloc(state->buffer, state->bytes);
+    if (!new_data) {
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+    state->buffer = new_data;
 
     for (y = state->yoff; y < state->ysize; y += tile_length) {
         int plane;
@@ -470,6 +478,15 @@ _decodeStrip(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imagin
         state->errcode = IMAGING_CODEC_MEMORY;
         return -1;
     }
+
+    if (strip_size > ((state->xsize * state->bits / planes + 7) / 8) * rows_per_strip) {
+        // If the strip size as expected by LibTiff isn't what we're expecting, abort.
+        // man:   TIFFStripSize returns the equivalent size for a strip of data as it would be returned in a
+        //        call to TIFFReadEncodedStrip ...
+        state->errcode = IMAGING_CODEC_BROKEN;
+        return -1;
+    }
+
     state->bytes = strip_size;
 
     TRACE(("StripSize: %d \n", state->bytes));

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -209,8 +209,37 @@ ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset) {
 }
 
 int
-_decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
-    // To avoid dealing with YCbCr subsampling, let libtiff handle it
+_pickUnpackers(Imaging im, ImagingCodecState state, TIFF *tiff, uint16 planarconfig, ImagingShuffler *unpackers) {
+    // if number of bands is 1, there is no difference with contig case
+    if (planarconfig == PLANARCONFIG_SEPARATE && im->bands > 1) {
+        uint16 bits_per_sample = 8;
+
+        TIFFGetFieldDefaulted(tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
+        if (bits_per_sample != 8 && bits_per_sample != 16) {
+            TRACE(("Invalid value for bits per sample: %d\n", bits_per_sample));
+            state->errcode = IMAGING_CODEC_BROKEN;
+            return -1;
+        }
+
+        // We'll pick appropriate set of unpackers depending on planar_configuration
+        // It does not matter if data is RGB(A), CMYK or LUV really,
+        // we just copy it plane by plane
+        unpackers[0] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "R;16N" : "R", NULL);
+        unpackers[1] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "G;16N" : "G", NULL);
+        unpackers[2] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "B;16N" : "B", NULL);
+        unpackers[3] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "A;16N" : "A", NULL);
+
+        return im->bands;
+    } else {
+        unpackers[0] = state->shuffle;
+
+        return 1;
+    }
+}
+
+int
+_decodeAsRGBA(Imaging im, ImagingCodecState state, TIFF *tiff) {
+    // To avoid dealing with YCbCr subsampling and other complications, let libtiff handle it
     // Use a TIFFRGBAImage wrapping the tiff image, and let libtiff handle
     // all of the conversion. Metadata read from the TIFFRGBAImage could
     // be different from the metadata that the base tiff returns.
@@ -256,13 +285,13 @@ _decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
              state->ysize,
              img.height));
         state->errcode = IMAGING_CODEC_BROKEN;
-        goto decodeycbcr_err;
+        goto decodergba_err;
     }
 
     /* overflow check for row byte size */
     if (INT_MAX / 4 < img.width) {
         state->errcode = IMAGING_CODEC_MEMORY;
-        goto decodeycbcr_err;
+        goto decodergba_err;
     }
 
     // TiffRGBAImages are 32bits/pixel.
@@ -271,7 +300,7 @@ _decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
     /* overflow check for realloc */
     if (INT_MAX / row_byte_size < rows_per_block) {
         state->errcode = IMAGING_CODEC_MEMORY;
-        goto decodeycbcr_err;
+        goto decodergba_err;
     }
 
     state->bytes = rows_per_block * row_byte_size;
@@ -283,7 +312,7 @@ _decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
     new_data = realloc(state->buffer, state->bytes);
     if (!new_data) {
         state->errcode = IMAGING_CODEC_MEMORY;
-        goto decodeycbcr_err;
+        goto decodergba_err;
     }
 
     state->buffer = new_data;
@@ -296,7 +325,7 @@ _decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
             -1) {
             TRACE(("Decode Error, y: %d\n", state->y));
             state->errcode = IMAGING_CODEC_BROKEN;
-            goto decodeycbcr_err;
+            goto decodergba_err;
         }
 
 #if WORDS_BIGENDIAN
@@ -323,11 +352,94 @@ _decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
         }
     }
 
-decodeycbcr_err:
+decodergba_err:
     TIFFRGBAImageEnd(&img);
     if (state->errcode != 0) {
         return -1;
     }
+    return 0;
+}
+
+int
+_decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, ImagingShuffler *unpackers) {
+    INT32 x, y, tile_y;
+    UINT32 tile_width, tile_length, current_tile_length, current_line,
+        current_tile_width, row_byte_size;
+    UINT8 *new_data;
+
+    TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
+    TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
+
+    /* overflow check for row_byte_size calculation */
+    if ((UINT32)INT_MAX / state->bits < tile_width) {
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+
+    // We could use TIFFTileSize, but for YCbCr data it returns subsampled data
+    // size
+    row_byte_size = (tile_width * state->bits / planes + 7) / 8;
+
+    /* overflow check for realloc */
+    if (INT_MAX / row_byte_size < tile_length) {
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+
+    state->bytes = row_byte_size * tile_length;
+
+    if (TIFFTileSize(tiff) > state->bytes) {
+        // If the tile size as expected by LibTiff isn't what we're expecting,
+        // abort.
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+
+    /* realloc to fit whole tile */
+    /* malloc check above */
+    new_data = realloc(state->buffer, state->bytes);
+    if (!new_data) {
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+
+    state->buffer = new_data;
+
+    TRACE(("TIFFTileSize: %d\n", state->bytes));
+
+    for (y = state->yoff; y < state->ysize; y += tile_length) {
+        int plane;
+        for (plane = 0; plane < planes; plane++) {
+            ImagingShuffler shuffler = unpackers[plane];
+            for (x = state->xoff; x < state->xsize; x += tile_width) {
+                if (TIFFReadTile(tiff, (tdata_t)state->buffer, x, y, 0, plane) == -1) {
+                    TRACE(("Decode Error, Tile at %dx%d\n", x, y));
+                    state->errcode = IMAGING_CODEC_BROKEN;
+                    return -1;
+                }
+
+                TRACE(("Read tile at %dx%d; \n\n", x, y));
+
+                current_tile_width = min((INT32) tile_width, state->xsize - x);
+                current_tile_length =  min((INT32) tile_length, state->ysize - y);
+                // iterate over each line in the tile and stuff data into image
+                for (tile_y = 0; tile_y < current_tile_length; tile_y++) {
+                    TRACE(("Writing tile data at %dx%d using tile_width: %d; \n", tile_y + y, x, current_tile_width));
+
+                    // UINT8 * bbb = state->buffer + tile_y * row_byte_size;
+                    // TRACE(("chars: %x%x%x%x\n", ((UINT8 *)bbb)[0], ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
+
+                    current_line = tile_y;
+
+                    shuffler((UINT8*) im->image[tile_y + y] + x * im->pixelsize,
+                             state->buffer + current_line * row_byte_size,
+                             current_tile_width
+                             );
+                }
+            }
+        }
+    }
+
     return 0;
 }
 
@@ -416,7 +528,7 @@ ImagingLibTiffDecode(
     TIFF *tiff;
     uint16 photometric = 0;  // init to not PHOTOMETRIC_YCBCR
     uint16 compression;
-    int isYCbCr = 0;
+    int readAsRGBA = 0;
     uint16 planarconfig = 0;
     int planes = 1;
     ImagingShuffler unpackers[4];
@@ -520,124 +632,27 @@ ImagingLibTiffDecode(
     TIFFGetField(tiff, TIFFTAG_COMPRESSION, &compression);
     TIFFGetFieldDefaulted(tiff, TIFFTAG_PLANARCONFIG, &planarconfig);
 
-    isYCbCr = photometric == PHOTOMETRIC_YCBCR;
+    // Dealing with YCbCr images is complicated in case if subsampling
+    // Let LibTiff read them as RGBA
+    readAsRGBA = photometric == PHOTOMETRIC_YCBCR;
 
-    if (isYCbCr && compression == COMPRESSION_JPEG && planarconfig == PLANARCONFIG_CONTIG) {
-        // If using new JPEG compression, let libjpeg do RGB convertion
+    if (readAsRGBA && compression == COMPRESSION_JPEG && planarconfig == PLANARCONFIG_CONTIG) {
+        // If using new JPEG compression, let libjpeg do RGB convertion for performance reasons
         TIFFSetField(tiff, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
-        isYCbCr = 0;
+        readAsRGBA = 0;
     }
 
-    if (isYCbCr) {
-        _decodeYCbCr(im, state, tiff);
+    if (readAsRGBA) {
+        _decodeAsRGBA(im, state, tiff);
     }
     else {
-        // YCbCr data is read as RGB by libtiff and we don't need to worry about planar storage in that case
-        // if number of bands is 1, there is no difference with contig case
-        if (planarconfig == PLANARCONFIG_SEPARATE &&
-            im->bands > 1 &&
-            !isYCbCr) {
-
-            uint16 bits_per_sample = 8;
-
-            TIFFGetFieldDefaulted(tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
-            if (bits_per_sample != 8 && bits_per_sample != 16) {
-                TRACE(("Invalid value for bits per sample: %d\n", bits_per_sample));
-                state->errcode = IMAGING_CODEC_BROKEN;
-                goto decode_err;
-            }
-
-            planes = im->bands;
-
-            // We'll pick appropriate set of unpackers depending on planar_configuration
-            // It does not matter if data is RGB(A), CMYK or LUV really,
-            // we just copy it plane by plane
-            unpackers[0] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "R;16N" : "R", NULL);
-            unpackers[1] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "G;16N" : "G", NULL);
-            unpackers[2] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "B;16N" : "B", NULL);
-            unpackers[3] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "A;16N" : "A", NULL);
-        } else {
-            unpackers[0] = state->shuffle;
+        planes = _pickUnpackers(im, state, tiff, planarconfig, unpackers);
+        if (planes <= 0) {
+            goto decode_err;
         }
 
         if (TIFFIsTiled(tiff)) {
-            INT32 x, y, tile_y;
-            UINT32 tile_width, tile_length, current_tile_length, current_line,
-                current_tile_width, row_byte_size;
-            UINT8 *new_data;
-
-            TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
-            TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
-
-            /* overflow check for row_byte_size calculation */
-            if ((UINT32)INT_MAX / state->bits < tile_width) {
-                state->errcode = IMAGING_CODEC_MEMORY;
-                goto decode_err;
-            }
-
-            // We could use TIFFTileSize, but for YCbCr data it returns subsampled data
-            // size
-            row_byte_size = (tile_width * state->bits / planes + 7) / 8;
-
-            /* overflow check for realloc */
-            if (INT_MAX / row_byte_size < tile_length) {
-                state->errcode = IMAGING_CODEC_MEMORY;
-                goto decode_err;
-            }
-
-            state->bytes = row_byte_size * tile_length;
-
-            if (TIFFTileSize(tiff) > state->bytes) {
-                // If the tile size as expected by LibTiff isn't what we're expecting,
-                // abort.
-                state->errcode = IMAGING_CODEC_MEMORY;
-                goto decode_err;
-            }
-
-            /* realloc to fit whole tile */
-            /* malloc check above */
-            new_data = realloc(state->buffer, state->bytes);
-            if (!new_data) {
-                state->errcode = IMAGING_CODEC_MEMORY;
-                goto decode_err;
-            }
-
-            state->buffer = new_data;
-
-            TRACE(("TIFFTileSize: %d\n", state->bytes));
-
-            for (y = state->yoff; y < state->ysize; y += tile_length) {
-                int plane;
-                for (plane = 0; plane < planes; plane++) {
-                    ImagingShuffler shuffler = unpackers[plane];
-                    for (x = state->xoff; x < state->xsize; x += tile_width) {
-                        if (TIFFReadTile(tiff, (tdata_t)state->buffer, x, y, 0, plane) == -1) {
-                            TRACE(("Decode Error, Tile at %dx%d\n", x, y));
-                            state->errcode = IMAGING_CODEC_BROKEN;
-                            goto decode_err;
-                        }
-
-                        TRACE(("Read tile at %dx%d; \n\n", x, y));
-
-                        current_tile_width = min((INT32) tile_width, state->xsize - x);
-                        current_tile_length =  min((INT32) tile_length, state->ysize - y);
-                        // iterate over each line in the tile and stuff data into image
-                        for (tile_y = 0; tile_y < current_tile_length; tile_y++) {
-                            TRACE(("Writing tile data at %dx%d using tile_width: %d; \n", tile_y + y, x, current_tile_width));
-
-                            // UINT8 * bbb = state->buffer + tile_y * row_byte_size;
-                            // TRACE(("chars: %x%x%x%x\n", ((UINT8 *)bbb)[0], ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
-
-                            current_line = tile_y;
-
-                            shuffler((UINT8*) im->image[tile_y + y] + x * im->pixelsize,
-                                     state->buffer + current_line * row_byte_size,
-                                     current_tile_width
-                                     );
-                        }
-                    }
-                }
-            }
+            _decodeTile(im, state, tiff, planes, unpackers);
         }
         else {
             _decodeStrip(im, state, tiff, planes, unpackers);

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -401,6 +401,7 @@ ImagingLibTiffDecode(
     char *mode = "r";
     TIFF *tiff;
     uint16 photometric = 0;  // init to not PHOTOMETRIC_YCBCR
+    uint16 compression;
     int isYCbCr = 0;
     uint16 planarconfig = 0;
     int planes = 1;
@@ -502,8 +503,16 @@ ImagingLibTiffDecode(
     }
 
     TIFFGetField(tiff, TIFFTAG_PHOTOMETRIC, &photometric);
-    isYCbCr = photometric == PHOTOMETRIC_YCBCR;
+    TIFFGetField(tiff, TIFFTAG_COMPRESSION, &compression);
     TIFFGetFieldDefaulted(tiff, TIFFTAG_PLANARCONFIG, &planarconfig);
+
+    isYCbCr = photometric == PHOTOMETRIC_YCBCR;
+
+    if (isYCbCr && compression == COMPRESSION_JPEG && planarconfig == PLANARCONFIG_CONTIG) {
+        // If using new JPEG compression, let libjpeg do RGB convertion
+        TIFFSetField(tiff, TIFFTAG_JPEGCOLORMODE, JPEGCOLORMODE_RGB);
+        isYCbCr = 0;
+    }
 
     // YCbCr data is read as RGB by libtiff and we don't need to worry about planar storage in that case
     // if number of bands is 1, there is no difference with contig case

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -289,6 +289,10 @@ _decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
             goto decodeycbcr_err;
         }
 
+#if WORDS_BIGENDIAN
+        TIFFSwabArrayOfLong((UINT32 *)state->buffer, img.width * rows_to_read);
+#endif
+
         TRACE(("Decoded strip for row %d \n", state->y));
 
         // iterate over each row in the strip and stuff data into image
@@ -609,6 +613,10 @@ ImagingLibTiffDecode(
                             state->errcode = IMAGING_CODEC_BROKEN;
                             goto decode_err;
                         }
+
+#if WORDS_BIGENDIAN
+                    TIFFSwabArrayOfLong((UINT32 *)state->buffer, tile_width * tile_length);
+#endif
                     } else {
                         if (TIFFReadTile(tiff, (tdata_t)state->buffer, x, y, 0, plane) == -1) {
                             TRACE(("Decode Error, Tile at %dx%d\n", x, y));

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -209,24 +209,34 @@ ImagingLibTiffInit(ImagingCodecState state, int fp, uint32 offset) {
 }
 
 int
-_decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
+_decodeYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
     // To avoid dealing with YCbCr subsampling, let libtiff handle it
     // Use a TIFFRGBAImage wrapping the tiff image, and let libtiff handle
     // all of the conversion. Metadata read from the TIFFRGBAImage could
     // be different from the metadata that the base tiff returns.
 
-    INT32 strip_row;
+    INT32 current_row;
     UINT8 *new_data;
-    UINT32 rows_per_strip, row_byte_size, rows_to_read;
+    UINT32 rows_per_block, row_byte_size, rows_to_read;
     int ret;
     TIFFRGBAImage img;
     char emsg[1024] = "";
 
-    ret = TIFFGetFieldDefaulted(tiff, TIFFTAG_ROWSPERSTRIP, &rows_per_strip);
-    if (ret != 1) {
-        rows_per_strip = state->ysize;
+    // Since using TIFFRGBAImage* functions, we can read whole tiff into rastrr in one call
+    // Let's select smaller block size. Multiplying image width by (tile length OR rows per strip)
+    // gives us manageable block size in pixels
+    if (TIFFIsTiled(tiff)) {
+        ret = TIFFGetFieldDefaulted(tiff, TIFFTAG_TILELENGTH, &rows_per_block);
     }
-    TRACE(("RowsPerStrip: %u \n", rows_per_strip));
+    else {
+        ret = TIFFGetFieldDefaulted(tiff, TIFFTAG_ROWSPERSTRIP, &rows_per_block);
+    }
+
+    if (ret != 1) {
+        rows_per_block = state->ysize;
+    }
+
+    TRACE(("RowsPerBlock: %u \n", rows_per_block));
 
     if (!(TIFFRGBAImageOK(tiff, emsg) && TIFFRGBAImageBegin(&img, tiff, 0, emsg))) {
         TRACE(("Decode error, msg: %s", emsg));
@@ -259,14 +269,14 @@ _decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
     row_byte_size = img.width * 4;
 
     /* overflow check for realloc */
-    if (INT_MAX / row_byte_size < rows_per_strip) {
+    if (INT_MAX / row_byte_size < rows_per_block) {
         state->errcode = IMAGING_CODEC_MEMORY;
         goto decodeycbcr_err;
     }
 
-    state->bytes = rows_per_strip * row_byte_size;
+    state->bytes = rows_per_block * row_byte_size;
 
-    TRACE(("StripSize: %d \n", state->bytes));
+    TRACE(("BlockSize: %d \n", state->bytes));
 
     /* realloc to fit whole strip */
     /* malloc check above */
@@ -278,9 +288,9 @@ _decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
 
     state->buffer = new_data;
 
-    for (; state->y < state->ysize; state->y += rows_per_strip) {
+    for (; state->y < state->ysize; state->y += rows_per_block) {
         img.row_offset = state->y;
-        rows_to_read = min(rows_per_strip, img.height - state->y);
+        rows_to_read = min(rows_per_block, img.height - state->y);
 
         if (TIFFRGBAImageGet(&img, (UINT32 *)state->buffer, img.width, rows_to_read) ==
             -1) {
@@ -296,19 +306,19 @@ _decodeStripYCbCr(Imaging im, ImagingCodecState state, TIFF *tiff) {
         TRACE(("Decoded strip for row %d \n", state->y));
 
         // iterate over each row in the strip and stuff data into image
-        for (strip_row = 0;
-             strip_row < min((INT32)rows_per_strip, state->ysize - state->y);
-             strip_row++) {
-            TRACE(("Writing data into line %d ; \n", state->y + strip_row));
+        for (current_row = 0;
+             current_row < min((INT32)rows_per_block, state->ysize - state->y);
+             current_row++) {
+            TRACE(("Writing data into line %d ; \n", state->y + current_row));
 
-            // UINT8 * bbb = state->buffer + strip_row * (state->bytes /
-            // rows_per_strip); TRACE(("chars: %x %x %x %x\n", ((UINT8 *)bbb)[0],
+            // UINT8 * bbb = state->buffer + current_row * (state->bytes /
+            // rows_per_block); TRACE(("chars: %x %x %x %x\n", ((UINT8 *)bbb)[0],
             // ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
 
             state->shuffle(
-                (UINT8 *)im->image[state->y + state->yoff + strip_row] +
+                (UINT8 *)im->image[state->y + state->yoff + current_row] +
                     state->xoff * im->pixelsize,
-                state->buffer + strip_row * row_byte_size,
+                state->buffer + current_row * row_byte_size,
                 state->xsize);
         }
     }
@@ -518,172 +528,142 @@ ImagingLibTiffDecode(
         isYCbCr = 0;
     }
 
-    // YCbCr data is read as RGB by libtiff and we don't need to worry about planar storage in that case
-    // if number of bands is 1, there is no difference with contig case
-    if (planarconfig == PLANARCONFIG_SEPARATE &&
-        im->bands > 1 &&
-        !isYCbCr) {
-
-        uint16 bits_per_sample = 8;
-
-        TIFFGetFieldDefaulted(tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
-        if (bits_per_sample != 8 && bits_per_sample != 16) {
-            TRACE(("Invalid value for bits per sample: %d\n", bits_per_sample));
-            state->errcode = IMAGING_CODEC_BROKEN;
-            goto decode_err;
-        }
-
-        planes = im->bands;
-
-        // We'll pick appropriate set of unpackers depending on planar_configuration
-        // It does not matter if data is RGB(A), CMYK or LUV really,
-        // we just copy it plane by plane
-        unpackers[0] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "R;16N" : "R", NULL);
-        unpackers[1] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "G;16N" : "G", NULL);
-        unpackers[2] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "B;16N" : "B", NULL);
-        unpackers[3] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "A;16N" : "A", NULL);
-    } else {
-        unpackers[0] = state->shuffle;
+    if (isYCbCr) {
+        _decodeYCbCr(im, state, tiff);
     }
+    else {
+        // YCbCr data is read as RGB by libtiff and we don't need to worry about planar storage in that case
+        // if number of bands is 1, there is no difference with contig case
+        if (planarconfig == PLANARCONFIG_SEPARATE &&
+            im->bands > 1 &&
+            !isYCbCr) {
 
-    if (TIFFIsTiled(tiff)) {
-        INT32 x, y, tile_y;
-        UINT32 tile_width, tile_length, current_tile_length, current_line,
-            current_tile_width, row_byte_size;
-        UINT8 *new_data;
+            uint16 bits_per_sample = 8;
 
-        TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
-        TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
-
-        /* overflow check for row_byte_size calculation */
-        if ((UINT32)INT_MAX / state->bits < tile_width) {
-            state->errcode = IMAGING_CODEC_MEMORY;
-            goto decode_err;
-        }
-
-        if (isYCbCr) {
-            row_byte_size = tile_width * 4;
-            /* sanity check, we use this value in shuffle below */
-            if (im->pixelsize != 4) {
+            TIFFGetFieldDefaulted(tiff, TIFFTAG_BITSPERSAMPLE, &bits_per_sample);
+            if (bits_per_sample != 8 && bits_per_sample != 16) {
+                TRACE(("Invalid value for bits per sample: %d\n", bits_per_sample));
                 state->errcode = IMAGING_CODEC_BROKEN;
                 goto decode_err;
             }
+
+            planes = im->bands;
+
+            // We'll pick appropriate set of unpackers depending on planar_configuration
+            // It does not matter if data is RGB(A), CMYK or LUV really,
+            // we just copy it plane by plane
+            unpackers[0] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "R;16N" : "R", NULL);
+            unpackers[1] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "G;16N" : "G", NULL);
+            unpackers[2] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "B;16N" : "B", NULL);
+            unpackers[3] = ImagingFindUnpacker("RGBA", bits_per_sample == 16 ? "A;16N" : "A", NULL);
         } else {
+            unpackers[0] = state->shuffle;
+        }
+
+        if (TIFFIsTiled(tiff)) {
+            INT32 x, y, tile_y;
+            UINT32 tile_width, tile_length, current_tile_length, current_line,
+                current_tile_width, row_byte_size;
+            UINT8 *new_data;
+
+            TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
+            TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
+
+            /* overflow check for row_byte_size calculation */
+            if ((UINT32)INT_MAX / state->bits < tile_width) {
+                state->errcode = IMAGING_CODEC_MEMORY;
+                goto decode_err;
+            }
+
             // We could use TIFFTileSize, but for YCbCr data it returns subsampled data
             // size
             row_byte_size = (tile_width * state->bits / planes + 7) / 8;
-        }
 
-        /* overflow check for realloc */
-        if (INT_MAX / row_byte_size < tile_length) {
-            state->errcode = IMAGING_CODEC_MEMORY;
-            goto decode_err;
-        }
+            /* overflow check for realloc */
+            if (INT_MAX / row_byte_size < tile_length) {
+                state->errcode = IMAGING_CODEC_MEMORY;
+                goto decode_err;
+            }
 
-        state->bytes = row_byte_size * tile_length;
+            state->bytes = row_byte_size * tile_length;
 
-        if (TIFFTileSize(tiff) > state->bytes) {
-            // If the tile size as expected by LibTiff isn't what we're expecting,
-            // abort.
-            state->errcode = IMAGING_CODEC_MEMORY;
-            goto decode_err;
-        }
+            if (TIFFTileSize(tiff) > state->bytes) {
+                // If the tile size as expected by LibTiff isn't what we're expecting,
+                // abort.
+                state->errcode = IMAGING_CODEC_MEMORY;
+                goto decode_err;
+            }
 
-        /* realloc to fit whole tile */
-        /* malloc check above */
-        new_data = realloc(state->buffer, state->bytes);
-        if (!new_data) {
-            state->errcode = IMAGING_CODEC_MEMORY;
-            goto decode_err;
-        }
+            /* realloc to fit whole tile */
+            /* malloc check above */
+            new_data = realloc(state->buffer, state->bytes);
+            if (!new_data) {
+                state->errcode = IMAGING_CODEC_MEMORY;
+                goto decode_err;
+            }
 
-        state->buffer = new_data;
+            state->buffer = new_data;
 
-        TRACE(("TIFFTileSize: %d\n", state->bytes));
+            TRACE(("TIFFTileSize: %d\n", state->bytes));
 
-        for (y = state->yoff; y < state->ysize; y += tile_length) {
-            int plane;
-            for (plane = 0; plane < planes; plane++) {
-                ImagingShuffler shuffler = unpackers[plane];
-                for (x = state->xoff; x < state->xsize; x += tile_width) {
-                    if (isYCbCr) {
-                        /* To avoid dealing with YCbCr subsampling, let libtiff handle it */
-                        if (!TIFFReadRGBATile(tiff, x, y, (UINT32 *)state->buffer)) {
-                            TRACE(("Decode Error, Tile at %dx%d\n", x, y));
-                            state->errcode = IMAGING_CODEC_BROKEN;
-                            goto decode_err;
-                        }
-
-#if WORDS_BIGENDIAN
-                    TIFFSwabArrayOfLong((UINT32 *)state->buffer, tile_width * tile_length);
-#endif
-                    } else {
+            for (y = state->yoff; y < state->ysize; y += tile_length) {
+                int plane;
+                for (plane = 0; plane < planes; plane++) {
+                    ImagingShuffler shuffler = unpackers[plane];
+                    for (x = state->xoff; x < state->xsize; x += tile_width) {
                         if (TIFFReadTile(tiff, (tdata_t)state->buffer, x, y, 0, plane) == -1) {
                             TRACE(("Decode Error, Tile at %dx%d\n", x, y));
                             state->errcode = IMAGING_CODEC_BROKEN;
                             goto decode_err;
                         }
-                    }
 
-                    TRACE(("Read tile at %dx%d; \n\n", x, y));
+                        TRACE(("Read tile at %dx%d; \n\n", x, y));
 
-                    current_tile_width = min((INT32) tile_width, state->xsize - x);
-                    current_tile_length =  min((INT32) tile_length, state->ysize - y);
-                    // iterate over each line in the tile and stuff data into image
-                    for (tile_y = 0; tile_y < current_tile_length; tile_y++) {
-                        TRACE(("Writing tile data at %dx%d using tile_width: %d; \n", tile_y + y, x, current_tile_width));
+                        current_tile_width = min((INT32) tile_width, state->xsize - x);
+                        current_tile_length =  min((INT32) tile_length, state->ysize - y);
+                        // iterate over each line in the tile and stuff data into image
+                        for (tile_y = 0; tile_y < current_tile_length; tile_y++) {
+                            TRACE(("Writing tile data at %dx%d using tile_width: %d; \n", tile_y + y, x, current_tile_width));
 
-                        // UINT8 * bbb = state->buffer + tile_y * row_byte_size;
-                        // TRACE(("chars: %x%x%x%x\n", ((UINT8 *)bbb)[0], ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
-                        /*
-                         * For some reason the TIFFReadRGBATile() function
-                         * chooses the lower left corner as the origin.
-                         * Vertically mirror by shuffling the scanlines
-                         * backwards
-                         */
+                            // UINT8 * bbb = state->buffer + tile_y * row_byte_size;
+                            // TRACE(("chars: %x%x%x%x\n", ((UINT8 *)bbb)[0], ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
 
-                        if (isYCbCr) {
-                            current_line = tile_length - tile_y - 1;
-                        } else {
                             current_line = tile_y;
-                        }
 
-                        shuffler((UINT8*) im->image[tile_y + y] + x * im->pixelsize,
-                                 state->buffer + current_line * row_byte_size,
-                                 current_tile_width
-                                 );
+                            shuffler((UINT8*) im->image[tile_y + y] + x * im->pixelsize,
+                                     state->buffer + current_line * row_byte_size,
+                                     current_tile_width
+                                     );
+                        }
                     }
                 }
             }
         }
-    } else {
-        if (!isYCbCr) {
+        else {
             _decodeStrip(im, state, tiff, planes, unpackers);
-        } else {
-            _decodeStripYCbCr(im, state, tiff);
         }
-    }
 
-    if (!state->errcode) {
-        // Check if raw mode was RGBa and it was stored on separate planes
-        // so we have to convert it to RGBA
-        if (planes > 3 && strcmp(im->mode, "RGBA") == 0) {
-            uint16 extrasamples;
-            uint16* sampleinfo;
-            ImagingShuffler shuffle;
-            INT32 y;
+        if (!state->errcode) {
+            // Check if raw mode was RGBa and it was stored on separate planes
+            // so we have to convert it to RGBA
+            if (planes > 3 && strcmp(im->mode, "RGBA") == 0) {
+                uint16 extrasamples;
+                uint16* sampleinfo;
+                ImagingShuffler shuffle;
+                INT32 y;
 
-            TIFFGetFieldDefaulted(tiff, TIFFTAG_EXTRASAMPLES, &extrasamples, &sampleinfo);
+                TIFFGetFieldDefaulted(tiff, TIFFTAG_EXTRASAMPLES, &extrasamples, &sampleinfo);
 
-            if (extrasamples >= 1 &&
-                (sampleinfo[0] == EXTRASAMPLE_UNSPECIFIED || sampleinfo[0] == EXTRASAMPLE_ASSOCALPHA)
-                ) {
-                shuffle = ImagingFindUnpacker("RGBA", "RGBa", NULL);
+                if (extrasamples >= 1 &&
+                    (sampleinfo[0] == EXTRASAMPLE_UNSPECIFIED || sampleinfo[0] == EXTRASAMPLE_ASSOCALPHA)
+                    ) {
+                    shuffle = ImagingFindUnpacker("RGBA", "RGBa", NULL);
 
-                for (y = state->yoff; y < state->ysize; y++) {
-                    UINT8* ptr = (UINT8*) im->image[y + state->yoff] +
-                        state->xoff * im->pixelsize;
-                    shuffle(ptr, ptr, state->xsize);
+                    for (y = state->yoff; y < state->ysize; y++) {
+                        UINT8* ptr = (UINT8*) im->image[y + state->yoff] +
+                            state->xoff * im->pixelsize;
+                        shuffle(ptr, ptr, state->xsize);
+                    }
                 }
             }
         }

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -362,38 +362,34 @@ decodergba_err:
 
 int
 _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, ImagingShuffler *unpackers) {
-    INT32 x, y, tile_y;
-    UINT32 tile_width, tile_length, current_tile_length, current_line,
-        current_tile_width, row_byte_size;
+    INT32 x, y, tile_y, current_tile_length, current_tile_width;
+    UINT32 tile_width, tile_length;
+    tsize_t tile_bytes_size, row_byte_size;
     UINT8 *new_data;
 
-    TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
-    TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
+    tile_bytes_size = TIFFTileSize(tiff);
 
-    /* overflow check for row_byte_size calculation */
-    if ((UINT32)INT_MAX / state->bits < tile_width) {
-        state->errcode = IMAGING_CODEC_MEMORY;
+    if (tile_bytes_size == 0) {
+        TRACE(("Decode Error, Can not calculate TileSize\n"));
+        state->errcode = IMAGING_CODEC_BROKEN;
         return -1;
     }
 
-    // We could use TIFFTileSize, but for YCbCr data it returns subsampled data
-    // size
-    row_byte_size = (tile_width * state->bits / planes + 7) / 8;
+    row_byte_size = TIFFTileRowSize(tiff);
+
+    if (row_byte_size == 0 || row_byte_size > tile_bytes_size) {
+        TRACE(("Decode Error, Can not calculate TileRowSize\n"));
+        state->errcode = IMAGING_CODEC_BROKEN;
+        return -1;
+    }
 
     /* overflow check for realloc */
-    if (INT_MAX / row_byte_size < tile_length) {
+    if (tile_bytes_size > INT_MAX - 1) {
         state->errcode = IMAGING_CODEC_MEMORY;
         return -1;
     }
 
-    state->bytes = row_byte_size * tile_length;
-
-    if (TIFFTileSize(tiff) > state->bytes) {
-        // If the tile size as expected by LibTiff isn't what we're expecting,
-        // abort.
-        state->errcode = IMAGING_CODEC_MEMORY;
-        return -1;
-    }
+    state->bytes = tile_bytes_size;
 
     /* realloc to fit whole tile */
     /* malloc check above */
@@ -402,8 +398,16 @@ _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imaging
         state->errcode = IMAGING_CODEC_MEMORY;
         return -1;
     }
-
     state->buffer = new_data;
+
+    TIFFGetField(tiff, TIFFTAG_TILEWIDTH, &tile_width);
+    TIFFGetField(tiff, TIFFTAG_TILELENGTH, &tile_length);
+
+    if (tile_width > INT_MAX || tile_length > INT_MAX) {
+        // state->x and state->y are ints
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
 
     TRACE(("TIFFTileSize: %d\n", state->bytes));
 
@@ -429,10 +433,8 @@ _decodeTile(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imaging
                     // UINT8 * bbb = state->buffer + tile_y * row_byte_size;
                     // TRACE(("chars: %x%x%x%x\n", ((UINT8 *)bbb)[0], ((UINT8 *)bbb)[1], ((UINT8 *)bbb)[2], ((UINT8 *)bbb)[3]));
 
-                    current_line = tile_y;
-
                     shuffler((UINT8*) im->image[tile_y + y] + x * im->pixelsize,
-                             state->buffer + current_line * row_byte_size,
+                             state->buffer + tile_y * row_byte_size,
                              current_tile_width
                              );
                 }
@@ -447,37 +449,39 @@ int
 _decodeStrip(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, ImagingShuffler *unpackers) {
     INT32 strip_row = 0;
     UINT8 *new_data;
-    UINT32 rows_per_strip, row_byte_size;
+    UINT32 rows_per_strip;
     int ret;
+    tsize_t strip_size, row_byte_size;
 
     ret = TIFFGetField(tiff, TIFFTAG_ROWSPERSTRIP, &rows_per_strip);
-    if (ret != 1) {
+    if (ret != 1 || rows_per_strip==(UINT32)(-1)) {
         rows_per_strip = state->ysize;
     }
-    TRACE(("RowsPerStrip: %u \n", rows_per_strip));
 
-    // We could use TIFFStripSize, but for YCbCr data it returns subsampled data size
-    row_byte_size = (state->xsize * state->bits / planes + 7) / 8;
-
-    /* overflow check for realloc */
-    if (INT_MAX / row_byte_size < rows_per_strip) {
+    if (rows_per_strip > INT_MAX) {
         state->errcode = IMAGING_CODEC_MEMORY;
         return -1;
     }
 
-    state->bytes = rows_per_strip * row_byte_size;
+    TRACE(("RowsPerStrip: %u\n", rows_per_strip));
+
+    strip_size = TIFFStripSize(tiff);
+    if (strip_size > INT_MAX - 1) {
+        state->errcode = IMAGING_CODEC_MEMORY;
+        return -1;
+    }
+    state->bytes = strip_size;
 
     TRACE(("StripSize: %d \n", state->bytes));
 
-    if (TIFFStripSize(tiff) > state->bytes) {
-        // If the strip size as expected by LibTiff isn't what we're expecting, abort.
-        // man:   TIFFStripSize returns the equivalent size for a strip of data as it
-        // would be returned in a
-        //        call to TIFFReadEncodedStrip ...
+    row_byte_size = TIFFScanlineSize(tiff);
 
-        state->errcode = IMAGING_CODEC_MEMORY;
+    if (row_byte_size == 0 || row_byte_size > strip_size) {
+        state->errcode = IMAGING_CODEC_BROKEN;
         return -1;
     }
+
+    TRACE(("RowsByteSize: %u \n", row_byte_size));
 
     /* realloc to fit whole strip */
     /* malloc check above */

--- a/src/libImaging/TiffDecode.c
+++ b/src/libImaging/TiffDecode.c
@@ -514,7 +514,7 @@ _decodeStrip(Imaging im, ImagingCodecState state, TIFF *tiff, int planes, Imagin
         int plane;
         for (plane = 0; plane < planes; plane++) {
             ImagingShuffler shuffler = unpackers[plane];
-            if (TIFFReadEncodedStrip(tiff, TIFFComputeStrip(tiff, state->y, plane), (tdata_t)state->buffer, -1) == -1) {
+            if (TIFFReadEncodedStrip(tiff, TIFFComputeStrip(tiff, state->y, plane), (tdata_t)state->buffer, strip_size) == -1) {
                 TRACE(("Decode Error, strip %d\n", TIFFComputeStrip(tiff, state->y, 0)));
                 state->errcode = IMAGING_CODEC_BROKEN;
                 return -1;


### PR DESCRIPTION
After trying to dig around https://github.com/python-pillow/Pillow/pull/5178 to fix windows 32bit issue, I found out that there are few tweaks to make.

* We could use one function to read image as RGBA, it's same for tiled/striped cases anyway. Additionally, previously reading tile as RGBA in a loop internally call for the same initialization procedure we can do just once.
* For YCbCr images with new jpeg compression and planar contig configuration, it's possible to keep using tile/strip access if we instruct libjpeg to decode straight into RGB for us - therefore saving on extra hoops of TiffReadRGBA* methods
* Fix Big Endian tests by swapping uint32 values in case of TiffReadRGBA is used
* Finally, pull code into few smaller functions for easier comprehension


(might be easier to review by commit)
