### PR TITLE
Added oss-fuzz badge

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,10 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://github.com/python-pillow/Pillow/actions/workflows/tidelift.yml
    :alt: Tidelift Align
 
+.. image:: https://oss-fuzz-build-logs.storage.googleapis.com/badges/pillow.svg
+   :target: https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:pillow
+   :alt: Fuzzing Status
+
 .. image:: https://img.shields.io/pypi/v/pillow.svg
    :target: https://pypi.org/project/Pillow/
    :alt: Latest PyPI version


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6717

Adds the oss-fuzz badge to the documentation index as well.