### PR TITLE
Use "parallel" config setting and 4 as defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,21 @@ from pybind11.setup_helpers import ParallelCompile
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
-ParallelCompile("MAX_CONCURRENCY").install()
+configuration: dict[str, list[str]] = {}
+
+# parse configuration from _custom_build/backend.py
+while sys.argv[-1].startswith("--pillow-configuration="):
+    _, key, value = sys.argv.pop().split("=", 2)
+    configuration.setdefault(key, []).append(value)
+
+default = int(configuration.get("parallel", ["4"])[-1])
+ParallelCompile("MAX_CONCURRENCY", default).install()
 
 
 def get_version() -> str:
     version_file = "src/PIL/_version.py"
     with open(version_file, encoding="utf-8") as f:
         return f.read().split('"')[1]
-
-
-configuration: dict[str, list[str]] = {}
 
 
 PILLOW_VERSION = get_version()
@@ -1051,11 +1056,6 @@ ext_modules = [
     Extension("PIL._imagingmorph", ["src/_imagingmorph.c"]),
 ]
 
-
-# parse configuration from _custom_build/backend.py
-while sys.argv[-1].startswith("--pillow-configuration="):
-    _, key, value = sys.argv.pop().split("=", 2)
-    configuration.setdefault(key, []).append(value)
 
 try:
     setup(


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8990

https://pillow.readthedocs.io/en/stable/installation/building-from-source.html#build-options
> Config setting: -C parallel=n. Can also be given with environment variable: MAX_CONCURRENCY=n. Pillow can use multiprocessing to build the extension. Setting -C parallel=n sets the number of CPUs to use to n, or can disable parallel building by using a setting of 1. By default, it uses 4 CPUs, or if 4 are not available, as many as are present.

This PR allows `-C parallel=n` to be used, and 4 otherwise.